### PR TITLE
add tags data to OnOff plugin's front end serialization

### DIFF
--- a/src/plugins/device_plugins/on_off/device_manager.py
+++ b/src/plugins/device_plugins/on_off/device_manager.py
@@ -1,4 +1,7 @@
 import logging
+from typing import List
+
+from sqlalchemy.orm import Session
 
 import src.models as models
 from src.dependencies import db_session
@@ -12,6 +15,12 @@ logger = logging.getLogger()
 
 class OnOffDeviceManager(BaseDeviceManager):
     """Manage "on_offs" and "devices" table rows using incoming device data."""
+
+    def get_devices_by_mqtt_id(self, mqtt_id: int | List[int]) -> OnOff:
+        db: Session = db_session.get()
+        if isinstance(mqtt_id, list):
+            return db.query(OnOff).filter(OnOff.device.has(models.Device.mqtt_id.in_(mqtt_id))).all()
+        return db.query(OnOff).filter(OnOff.device.has(models.Device.mqtt_id == mqtt_id)).one()
 
     def create_device(self, on_off_device: OnOffDeviceReceived) -> OnOff:
         logger.info('Creating device "%s"' % on_off_device)

--- a/src/plugins/device_plugins/on_off/duplex_messenger.py
+++ b/src/plugins/device_plugins/on_off/duplex_messenger.py
@@ -6,6 +6,7 @@ from src.plugins.base_duplex_messenger import (
     BaseDuplexMessenger,
 )
 from src.schemas.device import DeviceFrontend
+from src.schemas.tag import Tag
 from .schemas import OnOffDeviceFrontend, OnOffDeviceReceived
 
 
@@ -74,6 +75,8 @@ class OnOffDuplexMessenger(BaseDuplexMessenger):
                 remote_name=db_on_off_device.device.name,
                 last_seen=str(db_on_off_device.device.last_seen),
             )
+            if db_on_off_device.device.tags:
+                device.tags = [Tag(id=tag.id, name=tag.name) for tag in db_on_off_device.device.tags]
 
             on_off_data = OnOffDeviceFrontend(
                 device=device,

--- a/src/virtual_client.py
+++ b/src/virtual_client.py
@@ -1,7 +1,12 @@
 import logging
+from time import sleep
 
+from sqlalchemy.exc import IntegrityError
+
+from src.crud import create_tag, put_device_tags
 from src.mqtt.client import MQTTClient
 from src.plugins.discover_virtual_clients import discover_virtual_clients
+from src.schemas import TagBase
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,3 +29,36 @@ while not vcs_mqtt_client.is_connected():
 # Discover virtual clients
 logger.info("Discovering virtual clients...")
 virtual_clients = discover_virtual_clients(vcs_mqtt_client)
+
+tag_names = ["vsc tag 1", "vsc tag 2", "vsc tag 3"]
+tags = []
+for tag_name in tag_names:
+    try:
+        logger.info(f"Creating virtual client tag: {tag_name}")
+        tags.append(create_tag(TagBase(name=tag_name)))
+    except IntegrityError as e:
+        logger.error(f"Error creating virtual client tag: {e}")
+
+tag_ids = [tag.id for tag in tags]
+logger.info(f"{tag_ids=}")
+
+vcs_mqtt_client.request_all_devices_data()
+
+sleep(3)
+
+device_mqtt_ids_and_tag_ids = (
+    # Neo pixel
+    (900, [1, 2, 3]),
+    (901, [1, 2]),
+    # On off
+    (904, [2, 3]),
+    (906, [3]),
+    (907, [3]),
+)
+
+for device_mqtt_id, tag_ids in device_mqtt_ids_and_tag_ids:
+    try:
+        logger.info(f"Adding tags to virtual client device: {device_mqtt_id=} {tag_ids=}")
+        put_device_tags(device_mqtt_id, tag_ids)
+    except IntegrityError as e:
+        logger.error(f"Error putting virtual client device tags: {e}")


### PR DESCRIPTION
add tags data to OnOff plugin's front end serialization

when virtual-clients application starts up, automatically broadcast message for mqtt clients data, create tags, and associate these tags with some of the virtual clients